### PR TITLE
http → https

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,19 +14,19 @@
                 </script>
                 <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
                 <link rel="icon" href="/favicon.ico" type="image/x-icon">
-                <link href='http://fonts.googleapis.com/css?family=Slabo%2027px' rel='stylesheet' type='text/css'>
+                <link href='https://fonts.googleapis.com/css?family=Slabo%2027px' rel='stylesheet' type='text/css'>
                 <meta charset="utf-8"/>
                 <title>Katy Huff</title>
                 <!--[if lt IE 9]>
-                <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+                <script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script>
                 <![endif]-->
                 <link rel="stylesheet" media="all" href="css/maori.css"/>
                 <link rel="stylesheet" media="all" href="css/custom.css"/>
                 <meta name = "viewport" content = "initial-scale = .5">
 
-                <script type="text/javascript" src="http://use.typekit.com/rds7nju.js"></script>
+                <script type="text/javascript" src="https://use.typekit.com/rds7nju.js"></script>
                 <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
-                <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
+                <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js"></script>
                 <script type="text/javascript" src="js/supersized.2.0.js"></script>
                 <script type="text/javascript">$(function(){ $('#supersize').supersized();});</script>
         </head>
@@ -44,7 +44,7 @@
                         <ul>
                                 <li><a href="./work.html" title="Work">About Me</a></li>
                                 <li><a href="./contact.html" title="Contact Information">Contact Me</a></li>
-                                <li><a href="http://katyhuff.github.com/papers/cv.pdf" title="Curriculum Vitae">CV</a></li>
+                                <li><a href="./papers/cv.pdf" title="Curriculum Vitae">CV</a></li>
                                 <li><a href="./code.html" title="code">Code</a></li>
                                 <li><a href="./pubs.html" title="Publications">Publications</a></li>
                                 <li><a href="./research.html" title="Research">Research</a></li>


### PR DESCRIPTION
HTTPS is mandatory for new Github Sites.  Under HTTPS, insecure external HTTP resources will fail to load.  Changing them to HTTPS fixes the problem.

Existing Github Sites can opt into HTTPS: https://help.github.com/articles/securing-your-github-pages-site-with-https/
